### PR TITLE
Add pose data support

### DIFF
--- a/python/arflow/core.py
+++ b/python/arflow/core.py
@@ -216,10 +216,9 @@ class ARFlowService(service_pb2_grpc.ARFlowService):
             dtype=np.float32,
         )
 
-        t = np.frombuffer(buffer, dtype=np.float32)
-        transform = np.eye(4)
-        transform[:3, :] = t.reshape((3, 4))
-        transform[:3, 3] = 0
+        t = np.frombuffer(buffer, dtype=np.float32).reshape((3, 4))
+        transform = np.eye(4, dtype=np.float32)
+        transform[:3, :] = t
         transform = y_down_to_y_up @ transform
 
         return transform

--- a/unity/Assets/Scripts/ARFlowUnityDataSample.cs
+++ b/unity/Assets/Scripts/ARFlowUnityDataSample.cs
@@ -114,7 +114,7 @@ public class ARFlowUnityDataSample : MonoBehaviour
             },
             CameraTransform = new RegisterRequest.Types.CameraTransform()
             {
-                Enabled = false
+                Enabled = true
             }
         });
     }
@@ -153,10 +153,22 @@ public class ARFlowUnityDataSample : MonoBehaviour
         var depthBytes = _depthTexture.GetRawTextureData();
 
         Debug.Log($"pixelBytes length: {pixelBytes.Length}, depthBytes length: {depthBytes.Length}");
+
+        const int transformLength = 3 * 4 * sizeof(float);
+        var m = _captureCamera.transform.localToWorldMatrix;
+        var cameraTransformBytes = new byte[transformLength];
+        Buffer.BlockCopy(new[]
+        {
+            m.m00, m.m01, m.m02, m.m03,
+            m.m10, m.m11, m.m12, m.m13,
+            m.m20, m.m21, m.m22, m.m23
+        }, 0, cameraTransformBytes, 0, transformLength);
+
         _client.SendFrame(new DataFrameRequest()
         {
             Color = ByteString.CopyFrom(pixelBytes),
-            Depth = ByteString.CopyFrom(depthBytes)
+            Depth = ByteString.CopyFrom(depthBytes),
+            Transform = ByteString.CopyFrom(cameraTransformBytes)
         });
 
         _captureCamera.targetTexture = null;


### PR DESCRIPTION
## Summary
- preserve camera translation when decoding transforms
- send transform data from `ARFlowUnityDataSample`
- enable transform streaming in Unity sample

## Testing
- `poetry run pytest -q` *(fails: Command not found)*